### PR TITLE
Add 'ScriptFiles' to the list of available build actions in Visual Studio

### DIFF
--- a/src/Scripty.MsBuild/Scripty.MsBuild.targets
+++ b/src/Scripty.MsBuild/Scripty.MsBuild.targets
@@ -1,4 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Make the 'ScriptFiles' build action selectable in the file property panel in Visual Studio -->  
+  <ItemGroup>
+      <AvailableItemName Include="ScriptFiles" />
+  </ItemGroup>
+
   <PropertyGroup>
     <EvaluateScriptyFiles Condition=" '$(EvaluateScriptyFiles)' == '' ">true</EvaluateScriptyFiles>
   </PropertyGroup>


### PR DESCRIPTION
I added the "ScriptFiles" action as "AvailableItemName" to the MSBuild targets file. With this, the build action shows up in Visual Studio's list of build actions and can be selected for a file from within the UI.
