### PR TITLE
Changed EvaluateScriptyFiles to run before "BeforeBuild"

### DIFF
--- a/src/Scripty.MsBuild/Scripty.MsBuild.targets
+++ b/src/Scripty.MsBuild/Scripty.MsBuild.targets
@@ -23,7 +23,7 @@
 
   <UsingTask AssemblyFile="$(ScriptyAssembly)" TaskName="ScriptyTask" />
 
-  <Target Name="EvaluateScriptyFiles" DependsOnTargets="_ResolveScriptyFiles" BeforeTargets="BeforeCompile">
+  <Target Name="EvaluateScriptyFiles" DependsOnTargets="_ResolveScriptyFiles" BeforeTargets="BeforeBuild">
     <ScriptyTask ProjectFilePath="$(MSBuildProjectFullPath)" SolutionFilePath="$(SolutionPath)" ScriptyExecutable="$(ScriptyExecutable)" ScriptFiles="@(ScriptyFile)">
       <Output TaskParameter="NoneFiles" ItemName="NoneFiles" />
       <Output TaskParameter="CompileFiles" ItemName="CompileFiles" />


### PR DESCRIPTION
Fixes #58.
Changed the MSBuild task to run before "BeforeBuild" instead of "BeforeCompile" because "BeforeCompile" is run every time a NuGet package is installed.