### PR TITLE
Support for custom properties

### DIFF
--- a/src/Scripty.Core/ProjectTree/ProjectRoot.cs
+++ b/src/Scripty.Core/ProjectTree/ProjectRoot.cs
@@ -17,11 +17,13 @@ namespace Scripty.Core.ProjectTree
         private bool _generatedTree;
 
         public ProjectRoot(string filePath)
-            : this(filePath, null, null)
+            : this(filePath, null, null, null)
         {
         }
 
-        public ProjectRoot(string projectFilePath, string solutionFilePath, IReadOnlyDictionary<string, string> properties)
+        public ProjectRoot(string projectFilePath, string solutionFilePath,
+                    IReadOnlyDictionary<string, string> properties,
+                    IReadOnlyDictionary<string, string> customProperties)
             : base(null, string.Empty, null, null)
         {
             FilePath = projectFilePath;
@@ -38,9 +40,21 @@ namespace Scripty.Core.ProjectTree
                     _properties[pair.Key] = pair.Value;
                 }
             }
+
+            CustomProperties = new Dictionary<string, string>();
+
+            if (customProperties != null)
+            {
+                foreach (var pair in customProperties)
+                {
+                    CustomProperties[pair.Key] = pair.Value;
+                }
+            }
         }
 
         public string FilePath { get; }
+
+        public Dictionary<string, string> CustomProperties { get; }
 
         public MSBuildWorkspace Workspace
         {

--- a/src/Scripty.Core/ScriptEngine.cs
+++ b/src/Scripty.Core/ScriptEngine.cs
@@ -21,11 +21,13 @@ namespace Scripty.Core
         private readonly string _projectFilePath;
 
         public ScriptEngine(string projectFilePath)
-            : this(projectFilePath, null, null)
+            : this(projectFilePath, null, null, null)
         {
         }
 
-        public ScriptEngine(string projectFilePath, string solutionFilePath, IReadOnlyDictionary<string, string> properties)
+        public ScriptEngine(string projectFilePath, string solutionFilePath, 
+					IReadOnlyDictionary<string, string> properties,
+					IReadOnlyDictionary<string, string> customProperties = null)
         {
             if (string.IsNullOrEmpty(projectFilePath))
             {
@@ -47,7 +49,7 @@ namespace Scripty.Core
             }
 
             _projectFilePath = projectFilePath;
-            ProjectRoot = new ProjectRoot(projectFilePath, solutionFilePath, properties);
+            ProjectRoot = new ProjectRoot(projectFilePath, solutionFilePath, properties, customProperties);
         }
 
         public ProjectRoot ProjectRoot { get; }

--- a/src/Scripty.MsBuild/Scripty.MsBuild.csproj
+++ b/src/Scripty.MsBuild/Scripty.MsBuild.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScriptyTask.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/src/Scripty.MsBuild/ScriptyTask.cs
+++ b/src/Scripty.MsBuild/ScriptyTask.cs
@@ -28,6 +28,8 @@ namespace Scripty.MsBuild
 
         public string ScriptyExecutable { get; set; }
 
+        public string CustomProperties { get; set; }
+
         public ITaskItem[] ScriptFiles { get; set; }
 
         [Output]
@@ -183,9 +185,33 @@ namespace Scripty.MsBuild
                     .Where(x => !string.IsNullOrEmpty(x))
                     .Distinct()
                     .ToList(),
-                SolutionFilePath = SolutionFilePath?.Contains("*Undefined*") == true ? null : SolutionFilePath
+                SolutionFilePath = SolutionFilePath?.Contains("*Undefined*") == true ? null : SolutionFilePath,
+                CustomProperties = GetCustomProperties()
             };
             return JsonConvert.SerializeObject(settings);
+        }
+
+        private IDictionary<string, string> GetCustomProperties()
+        {
+            if (CustomProperties == null)
+                return null;
+
+            var result = new Dictionary<string, string>();
+            var parts = Utils.AsList(CustomProperties, new char[] { ';', '=' });
+
+            if (parts.Count % 2 != 0)
+            {
+                throw new Exception("Invalid CustomProperties");
+            }
+
+            for (int i = 0; i < parts.Count; i += 2)
+            {
+                var key = parts[i];
+                var value = parts[i + 1];
+
+                result[key] = value;
+            }
+            return result;
         }
 
         private IDictionary<string, string> GetMsBuildProperties()

--- a/src/Scripty.MsBuild/Settings.cs
+++ b/src/Scripty.MsBuild/Settings.cs
@@ -15,5 +15,6 @@ namespace Scripty.MsBuild
         public string SolutionFilePath = null;
         public IList<string> ScriptFilePaths = null;
         public IDictionary<string, string> Properties = null;
+        public IDictionary<string, string> CustomProperties = null;
     }
 }

--- a/src/Scripty.MsBuild/Utils.cs
+++ b/src/Scripty.MsBuild/Utils.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Scripty.MsBuild
+{
+	class Utils
+	{
+		private const char QUOTE_CHAR = '"';
+
+		static void SkipBlanks(ref int index, string csvString)
+		{
+			while (index < csvString.Length &&
+				csvString[index] == ' ')
+				index++;
+		}
+
+		public static List<string> AsList(string csvString, IEnumerable<char> separators = null, char escapeChar = '\\', bool skipBlanks = true)
+		{
+			HashSet<char> seps;
+			if (separators == null)
+			{
+				seps = new HashSet<char>();
+				seps.Add(';');
+			}
+			else
+				seps = new HashSet<char>(separators);
+
+			bool quoteCharIsSame = escapeChar == QUOTE_CHAR;
+
+				var list = new List<string>();
+				bool markOn = false;
+				csvString = skipBlanks ? csvString.Trim() : csvString;
+				if (csvString.Length == 0)
+					return list;
+				int index = 0;
+				StringBuilder s = new StringBuilder();
+				bool ending = false;
+
+				if (skipBlanks) SkipBlanks(ref index, csvString);
+
+				bool inEscape = false;
+
+				while (index < csvString.Length && !ending)
+				{
+					if (!inEscape && csvString[index] == QUOTE_CHAR)
+					{
+						// start quoted item
+						if (!markOn && s.Length == 0)
+							markOn = true;
+						else
+							// last quote
+							if (index == csvString.Length - 1)
+						{
+							list.Add(s.ToString());
+							s.Length = 0;
+							markOn = false;
+							ending = true;
+						}
+						else
+						{   // part of item ?
+							if (markOn)
+							{
+								// next quote mark for literal char
+								if (quoteCharIsSame && csvString[index + 1] == '"')
+								{
+									s.Append('"');
+									index++;
+								}
+								else
+									// end quoted item
+									markOn = false;
+							}
+							// not marked, is literal char
+							else
+								s.Append(QUOTE_CHAR);
+						}
+					}
+					else if (!markOn && csvString[index] == '\r')
+					{
+						// ignore cr
+					}
+					else if (!markOn && csvString[index] == '\n')
+					{
+						ending = true; break; // end of line
+					}
+					else
+					{
+						// check separator
+						if (seps.Contains(csvString[index]))
+						{
+							// delimiter is part of string
+							if (markOn)
+								s.Append(csvString[index]);
+							else
+							{
+								list.Add(s.ToString());
+								s.Length = 0;
+								markOn = false;
+								index++; // after ;
+								if (skipBlanks) SkipBlanks(ref index, csvString);
+								continue; // don't jump to increment index
+							}
+						}
+						else if (markOn && !inEscape && csvString[index] == escapeChar)
+						{
+							inEscape = true;
+						}
+						else
+						{
+							inEscape = false;
+							s.Append(csvString[index]);
+						}
+					}
+					index++;
+				}
+
+				// if line ends without Delimiter
+				if (s.Length > 0)
+					list.Add(s.ToString());
+				return list;
+			}
+	}
+}

--- a/src/Scripty/Program.cs
+++ b/src/Scripty/Program.cs
@@ -88,7 +88,8 @@ namespace Scripty
                 solutionFilePath = Path.Combine(Environment.CurrentDirectory, _settings.SolutionFilePath);
             }
 
-            ScriptEngine engine = new ScriptEngine(projectFilePath, solutionFilePath, _settings.Properties);
+            ScriptEngine engine = new ScriptEngine(projectFilePath, solutionFilePath,
+							_settings.Properties, _settings.CustomProperties);
 
             // Get script files if none were specified
             IReadOnlyList<string> finalScriptFilePaths;

--- a/src/Scripty/Settings.cs
+++ b/src/Scripty/Settings.cs
@@ -13,7 +13,8 @@ namespace Scripty
         public string SolutionFilePath = null;
         public IReadOnlyList<string> ScriptFilePaths = null;
         public IReadOnlyDictionary<string, string> Properties = null;
-        public bool Attach = false;
+		public IReadOnlyDictionary<string, string> CustomProperties = null;
+		public bool Attach = false;
 
         private IReadOnlyList<KeyValuePair<string, string>> _properties = null;
 


### PR DESCRIPTION
With this changes it is possible to add custom properties in ScriptyTask und use that in script.
Example:
<ScriptyTask ProjectFilePath="$(MSBuildProjectFullPath)" 
		SolutionFilePath="$(SolutionPath)" 
		ScriptyExecutable="$(ScriptyExecutable)"
		ScriptFiles="@(ScriptyFile)" 
		ContinueOnError="$(ScriptyContinueOnError)"
		**CustomProperties="ImgSettingsPath=$(ImgSettingsPath)"**
		CustomReferences="$(MSBuildProjectDirectory)\$(LibsDir)\Lib.dll">
      <Output TaskParameter="NoneFiles" ItemName="NoneFiles" />
      <Output TaskParameter="CompileFiles" ItemName="CompileFiles" />
      <Output TaskParameter="ContentFiles" ItemName="ContentFiles" />
      <Output TaskParameter="EmbeddedResourceFiles" ItemName="EmbeddedResourceFiles" />
    </ScriptyTask>

In Script you can access the property "ImgSettingsPath" with:
Context.Project.CustomProperties["ImgSettingsPath"]
#8 